### PR TITLE
Image bugfix

### DIFF
--- a/src/main/kotlin/com/github/timrs2998/pdfbuilder/ImageElement.kt
+++ b/src/main/kotlin/com/github/timrs2998/pdfbuilder/ImageElement.kt
@@ -8,7 +8,7 @@ import org.apache.pdfbox.pdmodel.graphics.image.JPEGFactory
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
 import java.awt.image.BufferedImage
 
-class ImageElement(parent: Element, private val imagePath: String = "", private val bufferedImage: BufferedImage?) :
+class ImageElement(parent: Element, private val imagePath: String = "", private val bufferedImage: BufferedImage? = null) :
   Element(parent) {
 
   var imgHeight: Int? = null
@@ -29,7 +29,7 @@ class ImageElement(parent: Element, private val imagePath: String = "", private 
     val pdImage = if (bufferedImage != null) JPEGFactory.createFromImage(
       pdDocument, bufferedImage )
     else PDImageXObject.createFromFile(imagePath, pdDocument)
-    
+
     imgHeight = imgHeight ?: pdImage.height
     imgWidth = imgWidth ?: pdImage.width
 

--- a/src/main/kotlin/com/github/timrs2998/pdfbuilder/ImageElement.kt
+++ b/src/main/kotlin/com/github/timrs2998/pdfbuilder/ImageElement.kt
@@ -7,10 +7,9 @@ import org.apache.pdfbox.pdmodel.PDPageContentStream.AppendMode.*
 import org.apache.pdfbox.pdmodel.graphics.image.JPEGFactory
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject
 import java.awt.image.BufferedImage
-import java.io.File
-import javax.imageio.ImageIO
 
-class ImageElement(parent: Element, private val imagePath: String) : Element(parent) {
+class ImageElement(parent: Element, private val imagePath: String = "", private val bufferedImage: BufferedImage?) :
+  Element(parent) {
 
   var imgHeight: Int? = null
   var imgWidth: Int? = null
@@ -27,21 +26,21 @@ class ImageElement(parent: Element, private val imagePath: String) : Element(par
     minHeight: Float
   ) {
 
-    val inputStream =
-
-    JPEGFactory.createFromImage(pdDocument, ImageIO.read(File(imagePath).inputStream()))
-    val pdImage = PDImageXObject.createFromFile(imagePath, pdDocument)
+    val pdImage = if (bufferedImage != null) JPEGFactory.createFromImage(
+      pdDocument, bufferedImage )
+    else PDImageXObject.createFromFile(imagePath, pdDocument)
+    
     imgHeight = imgHeight ?: pdImage.height
     imgWidth = imgWidth ?: pdImage.width
 
-    val pdPage = getPage(document, pdDocument, startY+imgHeight!!)
+    val pdPage = getPage(document, pdDocument, startY + imgHeight!!)
 
     val realStartX = when (inheritedHorizontalAlignment) {
       Alignment.LEFT -> startX
       Alignment.RIGHT -> endX - imgWidth!!
       Alignment.CENTER -> startX + (endX - startX - imgWidth!!) / 2f
     }
-    val transformedY = transformY(document, startY)-imgHeight!!
+    val transformedY = transformY(document, startY) - imgHeight!!
     PDPageContentStream(pdDocument, pdPage, APPEND, true).use { stream ->
       stream.drawImage(
         pdImage,

--- a/src/main/kotlin/com/github/timrs2998/pdfbuilder/KotlinBuilder.kt
+++ b/src/main/kotlin/com/github/timrs2998/pdfbuilder/KotlinBuilder.kt
@@ -1,6 +1,7 @@
 package com.github.timrs2998.pdfbuilder
 
 import org.apache.pdfbox.pdmodel.PDDocument
+import java.awt.image.BufferedImage
 
 /**
  * A DSL for Kotlin, Groovy or Java 8 consumers of this API.
@@ -35,11 +36,22 @@ fun Document.text(value: String, init: TextElement.() -> Unit = {}): TextElement
 }
 
 @DocumentMarker
-fun Document.image(imagePath: String) = this.image(imagePath, {})
+fun Document.image(imagePath: String) = this.image(imagePath) {}
 
 @DocumentMarker
 fun Document.image(imagePath: String, init: ImageElement.() -> Unit = {}): ImageElement {
-  val imageElement = ImageElement(this, imagePath)
+  val imageElement = ImageElement(this, imagePath, null)
+  imageElement.init()
+  this.children.add(imageElement)
+  return imageElement
+}
+
+@DocumentMarker
+fun Document.image(bufferedImage: BufferedImage): ImageElement  = this.image(bufferedImage) {}
+
+@DocumentMarker
+fun Document.image(bufferedImage: BufferedImage, init: ImageElement.() -> Unit = {}): ImageElement {
+  val imageElement = ImageElement(this, "", bufferedImage)
   imageElement.init()
   this.children.add(imageElement)
   return imageElement

--- a/src/main/kotlin/com/github/timrs2998/pdfbuilder/examples/KotlinDslExample.kt
+++ b/src/main/kotlin/com/github/timrs2998/pdfbuilder/examples/KotlinDslExample.kt
@@ -59,12 +59,9 @@ object KotlinDslExample {
           }
         }
       }
-
       image(img.path)
 
       text("Hola, mundo.")
-
-
     }.use { pdDocument ->
       pdDocument.save("output.pdf")
       pdDocument.close()


### PR DESCRIPTION
There is a bug in the image loading so that images can't be read from within a jar. It can be reproduced by putting an image inside your resources folder and making an image element that tries to read it and then bundling it into a jar and try to run it. 
To make it easier for users to load images I added an extra image DSL constructor that takes a buffered image parameter instead of just a path so users can choose how to load images. 
I also added a call to document.close() to the example document as it's recommended by pdfbox :) 