### PR TITLE
don't add starting position to height of table element

### DIFF
--- a/src/jvmMain/kotlin/com/github/timrs2998/pdfbuilder/TableElement.kt
+++ b/src/jvmMain/kotlin/com/github/timrs2998/pdfbuilder/TableElement.kt
@@ -19,7 +19,7 @@ class TableElement(override val parent: Document) : Element(parent) {
 
   override fun instanceHeight(width: Float, startY: Float): Float {
 //        return (header?.height(width, startY) ?: 0f) + rows.fold(0.0f, { sum, row -> sum + row.height(width, startY) })
-    var currentY = startY
+    var currentY = 0f
     var i = 0
     while (i < rows.size) {
       var row = rows[i]


### PR DESCRIPTION
Closes #9 

The comments around indicate that the original code had something to do with sticky header support, but from the output attached below, these still work

[output.pdf](https://github.com/timrs2998/pdf-builder/files/6091350/output.pdf)
